### PR TITLE
Add note about 1.12.2 added --cache-from flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.7-alpine
+RUN apk add --no-cache git
+RUN go get --v github.com/tonistiigi/buildcache/cmd/buildcache
+ENTRYPOINT ["/go/bin/buildcache"]
+CMD ["save", "-h"]

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ If `docker load` succeeds but cache still isn't being used in another machine tr
 #### compatibility
 
 Buildcache works with Docker v1.12 using only the remote API. To use buildcache in Docker v1.11 it needs to access the Docker storage directory directly. Use `-g` options to specify directory other than `/var/lib/docker`. Eariler Docker versions are not supported.
+
+**Note**: Docker 1.13 added support for `--cache-from` flag to the build command, replacing the need for this tool.

--- a/getcache.go
+++ b/getcache.go
@@ -72,6 +72,10 @@ func (b *buildCache) GetWithRemoteAPI(ctx context.Context, image string) (io.Rea
 		logrus.Warnf("Docker versions before v1.12.0 have a bug causing extracting build cache through remote API to take very long time and use lots of disk space. Please consider upgrading before using this tool.")
 	}
 
+	if versions.GreaterThanOrEqualTo(v.Version, "1.13.0") {
+		logrus.Warnf("Docker versions since v1.13.0 provide --cache-from flag to build command, consider using this instead")
+	}
+
 	id, err := b.getImageID(ctx, image)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Docker 1.12.2 (in RC at the time of this PR) has a `--cache-from` flag for the build command, it might be good for users to be notified of this flag
